### PR TITLE
JSON -> Object

### DIFF
--- a/src/entry.js
+++ b/src/entry.js
@@ -64,7 +64,7 @@ export default class Entry {
     return { start, end }
   }
 
-  toJSON() {
+  toObject() {
     return {
       _id: this._id,
       version: this.version,

--- a/src/entry.js
+++ b/src/entry.js
@@ -16,7 +16,7 @@ export default class Entry {
     }
 
     if (typeof message === 'object')
-      return this._fromJSON(message)
+      return this._fromObject(message)
 
     this.version = version
     this.user = user
@@ -28,7 +28,7 @@ export default class Entry {
     this.parseTags(message)
   }
 
-  _fromJSON(doc) {
+  _fromObject(doc) {
     Object.assign(this, doc)
     const start = new Date(this.start)
     const end = new Date(this.end)
@@ -84,7 +84,7 @@ export default class Entry {
     } 
   }
 
-  static fromJSON(doc) {
+  static fromObject(doc) {
     let e = new Entry(doc.user, doc)
 
     return e

--- a/src/test/entry.test.js
+++ b/src/test/entry.test.js
@@ -84,24 +84,24 @@ test('set timezone offset', t => {
 test('created date added to entry', t => {
   const today = new Date()  
   const e = new Entry(userId, '8am-5pm working on things')
-  const json = e.toObject()
+  const obj = e.toObject()
 
   t.ok(e.ref, 'ref is set')
   t.ok(moment(today).isSame(e.ref, 'second'), 'ref date is today')
-  t.ok(json.ref, 'ref is set on json')
-  t.ok(moment(today).isSame(json.ref, 'second'), 'json.ref date is today')
+  t.ok(obj.ref, 'ref is set on object')
+  t.ok(moment(today).isSame(obj.ref, 'second'), 'obj.ref date is today')
   t.end()
 })
 
 test('passed reference date added to entry', t => {
   const date = new Date(2016, 0, 1, 12, 15, 30) // Jan 1, 2016 12:15:30
   const e = new Entry(userId, '8am-5pm working on things', {date})
-  const json = e.toObject()
+  const obj = e.toObject()
 
   t.ok(e.ref, 'ref is set')
   t.ok(moment(date).isSame(e.ref, 'second'), 'ref date is Jan 1')
-  t.ok(json.ref, 'ref is set on json')
-  t.ok(moment(date).isSame(json.ref, 'second'), 'json.ref date is Jan 1')
+  t.ok(obj.ref, 'ref is set on object')
+  t.ok(moment(date).isSame(obj.ref, 'second'), 'obj.ref date is Jan 1')
   t.end()
 })
 
@@ -210,23 +210,23 @@ test('parsed time string is present', t => {
   t.end()
 })
 
-test('toObject() returns a json obj', t => {
+test('toObject() returns an object', t => {
   const e = new Entry(userId, '8am-10am worked on some things #tag1 #tag2')
 
-  const json = e.toObject()
-  t.equals(json.message, '8am-10am worked on some things #tag1 #tag2', 'message')
-  t.ok(json.hasDates, 'hasDates')
-  t.equals(e.start, json.start, 'start')
-  t.equals(e.end, json.end, 'end')
-  t.equals(json.duration.seconds, 2*60*60, 'duration seconds')
-  t.equals(json.time, e.time, 'time')
-  t.equals(json._id, e._id, '_id')
-  t.equals(json.version, version, 'version')
-  t.deepEquals(json.tags, [...e.tags], 'tags array')
-  t.ok(moment.utc(json.startArr).isSame(json.start), 'start and startArr are same date')
-  t.ok(moment.utc(json.endArr).isSame(json.end), 'end and endArr are same date')
-  t.ok(json.startArr instanceof Array, 'startArr is an array')
-  t.ok(json.endArr instanceof Array, 'endArr is an array')
+  const obj = e.toObject()
+  t.equals(obj.message, '8am-10am worked on some things #tag1 #tag2', 'message')
+  t.ok(obj.hasDates, 'hasDates')
+  t.equals(e.start, obj.start, 'start')
+  t.equals(e.end, obj.end, 'end')
+  t.equals(obj.duration.seconds, 2*60*60, 'duration seconds')
+  t.equals(obj.time, e.time, 'time')
+  t.equals(obj._id, e._id, '_id')
+  t.equals(obj.version, version, 'version')
+  t.deepEquals(obj.tags, [...e.tags], 'tags array')
+  t.ok(moment.utc(obj.startArr).isSame(obj.start), 'start and startArr are same date')
+  t.ok(moment.utc(obj.endArr).isSame(obj.end), 'end and endArr are same date')
+  t.ok(obj.startArr instanceof Array, 'startArr is an array')
+  t.ok(obj.endArr instanceof Array, 'endArr is an array')
 
   t.end()
 })
@@ -234,8 +234,8 @@ test('toObject() returns a json obj', t => {
 test('fromObject() will create an Entry from existing document', t => {
   const date = new Date('Jan 25, 2015 0:00:00')
   const existing = new Entry(userId, '8am-10am worked on things #tag1 #tag2', {date})
-  const json = existing.toObject()
-  const e = Entry.fromObject(json)
+  const obj = existing.toObject()
+  const e = Entry.fromObject(obj)
 
   t.equals(existing._id, e._id, '_id matches')
   t.equals(existing.version, e.version, 'version matches')

--- a/src/test/entry.test.js
+++ b/src/test/entry.test.js
@@ -231,11 +231,11 @@ test('toObject() returns a json obj', t => {
   t.end()
 })
 
-test('fromJSON() will create an Entry from existing document', t => {
+test('fromObject() will create an Entry from existing document', t => {
   const date = new Date('Jan 25, 2015 0:00:00')
   const existing = new Entry(userId, '8am-10am worked on things #tag1 #tag2', {date})
   const json = existing.toObject()
-  const e = Entry.fromJSON(json)
+  const e = Entry.fromObject(json)
 
   t.equals(existing._id, e._id, '_id matches')
   t.equals(existing.version, e.version, 'version matches')

--- a/src/test/entry.test.js
+++ b/src/test/entry.test.js
@@ -84,7 +84,7 @@ test('set timezone offset', t => {
 test('created date added to entry', t => {
   const today = new Date()  
   const e = new Entry(userId, '8am-5pm working on things')
-  const json = e.toJSON()
+  const json = e.toObject()
 
   t.ok(e.ref, 'ref is set')
   t.ok(moment(today).isSame(e.ref, 'second'), 'ref date is today')
@@ -96,7 +96,7 @@ test('created date added to entry', t => {
 test('passed reference date added to entry', t => {
   const date = new Date(2016, 0, 1, 12, 15, 30) // Jan 1, 2016 12:15:30
   const e = new Entry(userId, '8am-5pm working on things', {date})
-  const json = e.toJSON()
+  const json = e.toObject()
 
   t.ok(e.ref, 'ref is set')
   t.ok(moment(date).isSame(e.ref, 'second'), 'ref date is Jan 1')
@@ -210,10 +210,10 @@ test('parsed time string is present', t => {
   t.end()
 })
 
-test('toJSON() returns a json obj', t => {
+test('toObject() returns a json obj', t => {
   const e = new Entry(userId, '8am-10am worked on some things #tag1 #tag2')
 
-  const json = e.toJSON()
+  const json = e.toObject()
   t.equals(json.message, '8am-10am worked on some things #tag1 #tag2', 'message')
   t.ok(json.hasDates, 'hasDates')
   t.equals(e.start, json.start, 'start')
@@ -234,7 +234,7 @@ test('toJSON() returns a json obj', t => {
 test('fromJSON() will create an Entry from existing document', t => {
   const date = new Date('Jan 25, 2015 0:00:00')
   const existing = new Entry(userId, '8am-10am worked on things #tag1 #tag2', {date})
-  const json = existing.toJSON()
+  const json = existing.toObject()
   const e = Entry.fromJSON(json)
 
   t.equals(existing._id, e._id, '_id matches')


### PR DESCRIPTION
**This is a breaking API change**

JSON is not semantically correct, since JSON is not equivalent to Javascript objects.`fromJSON` accepts only Javascript objects and `toJSON` returns non-JSON formatted javascript objects. 

All of the code in the project and the use of this API really means to use it as `toObject` and `fromObject`, so this updates those calls to be more correct.

Alternatively I could change it to actually return JSON, but my understanding is that most of the code is really wanting a plain object. 

Doing this allows me to resolve tickbin/tickbin#227.