### PR TITLE
Version 0.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tickbin-parser",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "parse strings into entries",
   "main": "build/index.js",
   "scripts": {


### PR DESCRIPTION
**Breaking**: `Entry.toJSON` is now `Entry.toObject`
**Breaking**: `Entry.fromJSON` is now `Entry.fromObject`