### PR TITLE
Breaking: Provide message with time parsed out

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,21 +5,22 @@ A parser to take strings that look like "May 4 2-4pm I did some #stuff" and pars
 ## Install
 
 ```
-npm install tickbin-entry-parser
+npm install tickbin-parser
 ```
 
 ## Usage
 
 ```javascript
-import Parser from 'tickbin-entry-parser'
+import { Entry, parser } from 'tickbin-parser'
 
 //  userId may be undefined if you don't wish to associate entry with user
-const entry = new Parser(userId, 'May 4 2-4pm I did some #stuff')
+const entry = new Entry(userId, 'May 4 2-4pm I did some #stuff')
 //  entry = {
-//    version: 4,
+//    version: 5,
 //    user: undefined,
 //    _id: 'H1yifd_4',
-//    message: 'May 4 2-4pm I did some #stuff',
+//    original: 'May 4 2-4pm I did some #stuff',
+//    message: 'I did some #stuff',
 //    ref: Fri Jun 10 2016 10:02:14 GMT-0700 (PDT),
 //    hasDates: true,
 //    start: Wed May 04 2016 14:00:00 GMT-0700 (PDT),
@@ -33,6 +34,15 @@ const entry = new Parser(userId, 'May 4 2-4pm I did some #stuff')
 //      to: Wed May 04 2016 16:00:00 GMT-0700 (PDT)
 //    },
 //    tags: Set { '#stuff' }
+//  }
+
+const parse = parser('8am-10am test message')
+//  parse = {
+//    start: Thu Jul 21 2016 08:00:00 GMT-0700 (PDT),
+//    end: Thu Jul 21 2016 10:00:00 GMT-0700 (PDT),
+//    text: '8am-10am',
+//    message: 'test message',
+//    isRange: true
 //  }
 ```
 

--- a/src/entry.js
+++ b/src/entry.js
@@ -6,7 +6,7 @@ import parser from './parser'
 export const hashPattern = /(#\w+[\w-]*)/g
 export const version = 5
 export default class Entry {
-  constructor(user, message, opts = {}, timezoneOffset) {
+  constructor(user, originalMessage, opts = {}, timezoneOffset) {
     let { date } = opts
     if (timezoneOffset && !date) {
       //  ensure reference date is in users time and zone
@@ -15,17 +15,17 @@ export default class Entry {
       date = new Date()
     }
 
-    if (typeof message === 'object')
-      return this._fromObject(message)
+    if (typeof originalMessage === 'object')
+      return this._fromObject(originalMessage)
 
     this.version = version
     this.user = user
     this._id = shortid.generate()
-    this.message = message
+    this.original= originalMessage
     //  ensure ref is a date and not a moment
     this.ref = new Date(date)
-    this.parse(message, date, timezoneOffset)
-    this.parseTags(message)
+    this.parse(originalMessage, date, timezoneOffset)
+    this.parseTags(originalMessage)
   }
 
   _fromObject(doc) {
@@ -70,7 +70,7 @@ export default class Entry {
       version: this.version,
       ref: this.ref,
       user: this.user,
-      message: this.message,
+      original: this.original,
       hasDates: this.hasDates,
       start: this.start,
       startArr: this.startArr,

--- a/src/entry.js
+++ b/src/entry.js
@@ -34,14 +34,14 @@ export default class Entry {
     const end = new Date(this.end)
     const text = this.time
     const message = this.message
-    this.setDates({start, end, text, message})
+    this.setParsedFields({start, end, text, message})
     this.tags = new Set(doc.tags)
     return this
   }
 
   parse(msg, date, timezoneOffset) {
     let d = parser(msg, date, timezoneOffset)
-    if (d.isRange) this.setDates(d)
+    if (d.isRange) this.setParsedFields(d)
   }
 
   parseTags(message) {
@@ -49,7 +49,7 @@ export default class Entry {
     this.tags = new Set(message.match(hashPattern))
   }
 
-  setDates(opts) {
+  setParsedFields(opts) {
     this.hasDates = true
     this.start = opts.start
     this.startArr = moment(this.start).utc().toArray()

--- a/src/entry.js
+++ b/src/entry.js
@@ -33,7 +33,8 @@ export default class Entry {
     const start = new Date(this.start)
     const end = new Date(this.end)
     const text = this.time
-    this.setDates({start, end, text})
+    const message = this.message
+    this.setDates({start, end, text, message})
     this.tags = new Set(doc.tags)
     return this
   }
@@ -55,6 +56,7 @@ export default class Entry {
     this.end = opts.end
     this.endArr = moment(this.end).utc().toArray()
     this.time = opts.text
+    this.message = opts.message
     this.duration = new Duration(this.start, this.end)
   }
 
@@ -71,6 +73,7 @@ export default class Entry {
       ref: this.ref,
       user: this.user,
       original: this.original,
+      message: this.message,
       hasDates: this.hasDates,
       start: this.start,
       startArr: this.startArr,

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import Entry from './entry'
+import Entry, { hashPattern, version } from './entry'
 import parser from './parser'
 
-export { Entry, parser }
+export { Entry, hashPattern, version, parser }

--- a/src/parser.js
+++ b/src/parser.js
@@ -14,7 +14,8 @@ parser.refiners.push(dayOverlapRefiner)
 
 export default function(str, ref, timezoneOffset) {
   let rslt = parser.parse(str, ref)[0]
-  let isRange = rslt && rslt.start && rslt.end
+  //  ... && true || false makes sure isRange is a boolean
+  let isRange = (rslt && rslt.start && rslt.end && true) || false
 
   //  sets timezone to where user is located
   if (timezoneOffset && isRange) {

--- a/src/test/entry.test.js
+++ b/src/test/entry.test.js
@@ -258,3 +258,10 @@ test('return message with time stripped out', t => {
   t.equals(e.message, 'worked on some things #tag1 #tag2')
   t.end()
 })
+
+test('return message with date stripped out', t => {
+  const e = new Entry(userId, 'Feb 1 8-10am worked on some things #tag1 #tag2')
+
+  t.equals(e.message, 'worked on some things #tag1 #tag2')
+  t.end()
+})

--- a/src/test/entry.test.js
+++ b/src/test/entry.test.js
@@ -215,6 +215,7 @@ test('toObject() returns an object', t => {
 
   const obj = e.toObject()
   t.equals(obj.original, '8am-10am worked on some things #tag1 #tag2', 'original')
+  t.equals(obj.message, 'worked on some things #tag1 #tag2', 'message')
   t.ok(obj.hasDates, 'hasDates')
   t.equals(e.start, obj.start, 'start')
   t.equals(e.end, obj.end, 'end')
@@ -240,6 +241,7 @@ test('fromObject() will create an Entry from existing document', t => {
   t.equals(existing._id, e._id, '_id matches')
   t.equals(existing.version, e.version, 'version matches')
   t.equals(existing.original, e.original, 'original matches')
+  t.equals(existing.message, e.message, 'message matches')
   t.equals(e.tags.size, 2, '2 tags')
   t.equals(moment(existing.start).toString(), moment(e.start).toString(), 'start matches')
   t.equals(moment(existing.end).toString(), moment(e.end).toString(), 'end matches')
@@ -248,4 +250,11 @@ test('fromObject() will create an Entry from existing document', t => {
 
   t.end()
 
+})
+
+test('return message with time stripped out', t => {
+  const e = new Entry(userId, '8-10am worked on some things #tag1 #tag2')
+
+  t.equals(e.message, 'worked on some things #tag1 #tag2')
+  t.end()
 })

--- a/src/test/entry.test.js
+++ b/src/test/entry.test.js
@@ -16,7 +16,7 @@ test('simple entry construction 8am-10pm', t => {
   const e = new Entry(userId, '8am-10am worked on things')
   const { start, end } = e.getDates()
   t.ok(e.hasDates, 'entry has dates')
-  t.equals(e.message, '8am-10am worked on things')
+  t.equals(e.original, '8am-10am worked on things')
   t.equals(start.getHours(), 8, 'start is 8am')
   t.equals(end.getHours(), 10, 'start is 10am')
 
@@ -27,7 +27,7 @@ test('simple entry construction 8am-5pm', t => {
   const e = new Entry(userId, '8am-5pm worked on things')
   const { start, end } = e.getDates()
   t.ok(e.hasDates, 'entry has dates')
-  t.equals(e.message, '8am-5pm worked on things')
+  t.equals(e.original, '8am-5pm worked on things')
   t.equals(start.getHours(), 8, 'start is 8am')
   t.equals(end.getHours(), 17, 'end is 5pm')
 
@@ -214,7 +214,7 @@ test('toObject() returns an object', t => {
   const e = new Entry(userId, '8am-10am worked on some things #tag1 #tag2')
 
   const obj = e.toObject()
-  t.equals(obj.message, '8am-10am worked on some things #tag1 #tag2', 'message')
+  t.equals(obj.original, '8am-10am worked on some things #tag1 #tag2', 'original')
   t.ok(obj.hasDates, 'hasDates')
   t.equals(e.start, obj.start, 'start')
   t.equals(e.end, obj.end, 'end')
@@ -239,7 +239,7 @@ test('fromObject() will create an Entry from existing document', t => {
 
   t.equals(existing._id, e._id, '_id matches')
   t.equals(existing.version, e.version, 'version matches')
-  t.equals(existing.message, e.message, 'message matches')
+  t.equals(existing.original, e.original, 'original matches')
   t.equals(e.tags.size, 2, '2 tags')
   t.equals(moment(existing.start).toString(), moment(e.start).toString(), 'start matches')
   t.equals(moment(existing.end).toString(), moment(e.end).toString(), 'end matches')

--- a/src/test/parser.test.js
+++ b/src/test/parser.test.js
@@ -227,3 +227,15 @@ test('use timezone offset', t => {
 
   t.end()
 })
+
+test('isRange should be a boolean', t => {
+  //  Test TRUE
+  let { isRange: isTrue } = parser('8am-10am')
+  t.equal(typeof(isTrue), 'boolean', 'is a boolean when true')
+
+  //  Test FALSE
+  let { isRange: isFalse } = parser('8am')
+  t.equal(typeof(isFalse), 'boolean', 'is a boolean when false')
+
+  t.end()
+})


### PR DESCRIPTION
* Exports `hashPatter` and `version` Resolves #22 
* Updates README Resolves #21 
* Moves entry.message to entry.original
* Adds user input without time as entry.message
