### PR TITLE
Bump entry version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tickbin-parser",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "parse strings into entries",
   "main": "build/index.js",
   "scripts": {

--- a/src/entry.js
+++ b/src/entry.js
@@ -5,7 +5,7 @@ import parser from './parser'
 import durationParser from './durationParser'
 
 export const hashPattern = /(#\w+[\w-]*)/g
-export const version = 7
+export const version = 8
 export default class Entry {
   constructor(user, originalMessage, opts = {}, timezoneOffset) {
     let { date } = opts


### PR DESCRIPTION
We need to bump the version of entry because there is an upgrade script in tickbin/tickbin that fixes issues that were affected by a bug. The format of the entry itself does not change, so the only thing this PR does is bump the entry version.